### PR TITLE
feat(#20): 홈 - 특정 달 확정 약속 조회 기능 구현

### DIFF
--- a/src/main/java/com/kuit/conet/config/MvcConfig.java
+++ b/src/main/java/com/kuit/conet/config/MvcConfig.java
@@ -33,5 +33,6 @@ public class MvcConfig implements WebMvcConfigurer {
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/user");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/user/name");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/user/image");
+        registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/home/month");
     }
 }

--- a/src/main/java/com/kuit/conet/controller/HomeController.java
+++ b/src/main/java/com/kuit/conet/controller/HomeController.java
@@ -1,0 +1,28 @@
+package com.kuit.conet.controller;
+
+import com.kuit.conet.common.response.BaseResponse;
+import com.kuit.conet.dto.request.MonthPlanRequest;
+import com.kuit.conet.dto.response.MonthPlanResponse;
+import com.kuit.conet.service.HomeService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/home")
+public class HomeController {
+    private final HomeService homeService;
+
+    @GetMapping("/month")
+    public BaseResponse<MonthPlanResponse> getPlanOnMonth(HttpServletRequest httpRequest, @RequestBody @Valid MonthPlanRequest planRequest) {
+        MonthPlanResponse response = homeService.getPlanOnMonth(httpRequest, planRequest);
+        return new BaseResponse<>(response);
+    }
+}

--- a/src/main/java/com/kuit/conet/dao/HomeDao.java
+++ b/src/main/java/com/kuit/conet/dao/HomeDao.java
@@ -1,0 +1,36 @@
+package com.kuit.conet.dao;
+
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.SingleColumnRowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class HomeDao {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public HomeDao(DataSource dataSource) {
+        this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    public List<String> getPlanOnMonth(Long userId, String searchDate) {
+        // 해당 년, 월에 유저가 포함된 모든 모임의 모든 약속 -> fixed_date 만 distinct 로 검색
+        // team_member(userId, status) -> plan(teamId, fixed_date, status)
+
+        String sql = "select distinct(p.fixed_date) " +
+                "from team_member tm, plan p " +
+                "where tm.team_id = p.team_id " +
+                "and tm.user_id=:user_id and tm.status=1 " +
+                "and p.status=1 and date_format(p.fixed_date,'%Y-%m')=:search_date";
+        Map<String, Object> param = Map.of("user_id", userId,
+                "search_date", searchDate);
+
+        RowMapper<String> mapper = new SingleColumnRowMapper<>(String.class);
+
+        return jdbcTemplate.query(sql, param, mapper);
+    }
+}

--- a/src/main/java/com/kuit/conet/dto/request/MonthPlanRequest.java
+++ b/src/main/java/com/kuit/conet/dto/request/MonthPlanRequest.java
@@ -1,0 +1,12 @@
+package com.kuit.conet.dto.request;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class MonthPlanRequest {
+    String searchDate;
+    // yyyy-MM
+}

--- a/src/main/java/com/kuit/conet/dto/response/MonthPlanResponse.java
+++ b/src/main/java/com/kuit/conet/dto/response/MonthPlanResponse.java
@@ -1,0 +1,15 @@
+package com.kuit.conet.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class MonthPlanResponse {
+    int count;
+    List<Integer> dates;
+}

--- a/src/main/java/com/kuit/conet/service/HomeService.java
+++ b/src/main/java/com/kuit/conet/service/HomeService.java
@@ -1,0 +1,34 @@
+package com.kuit.conet.service;
+
+import com.kuit.conet.dao.HomeDao;
+import com.kuit.conet.dto.request.MonthPlanRequest;
+import com.kuit.conet.dto.response.MonthPlanResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HomeService {
+    private final HomeDao homeDao;
+
+    public MonthPlanResponse getPlanOnMonth(HttpServletRequest httpRequest, MonthPlanRequest planRequest) {
+        List<Integer> planDates = new ArrayList<>();
+
+        Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
+        String searchDate = planRequest.getSearchDate(); // yyyy-MM
+
+        List<String> dateList = homeDao.getPlanOnMonth(userId, searchDate);
+        for(String tempDate : dateList) {
+            Integer date = Integer.parseInt(tempDate.split("-")[2]);
+            planDates.add(date);
+        }
+
+        return new MonthPlanResponse(planDates.size(), planDates);
+    }
+}


### PR DESCRIPTION
## 홈 화면 `캘린더`에 표시될 특정 달의 약속

### 클라이언트
"yyyy-MM" 형태의 문자열 전달

### 반환 값
- 해당 년, 월에 유저가 포함되어 있는 모든 모임의 모든 약속