### PR TITLE
feat(#21): 홈 - 특정 날짜의 약속 조회 기능 구현

### DIFF
--- a/src/main/java/com/kuit/conet/config/MvcConfig.java
+++ b/src/main/java/com/kuit/conet/config/MvcConfig.java
@@ -36,5 +36,6 @@ public class MvcConfig implements WebMvcConfigurer {
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/plan/time");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/plan/user-time");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/home/month");
+        registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/home/day");
     }
 }

--- a/src/main/java/com/kuit/conet/controller/HomeController.java
+++ b/src/main/java/com/kuit/conet/controller/HomeController.java
@@ -1,7 +1,8 @@
 package com.kuit.conet.controller;
 
 import com.kuit.conet.common.response.BaseResponse;
-import com.kuit.conet.dto.request.MonthPlanRequest;
+import com.kuit.conet.dto.request.PlanRequest;
+import com.kuit.conet.dto.response.DayPlanResponse;
 import com.kuit.conet.dto.response.MonthPlanResponse;
 import com.kuit.conet.service.HomeService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,9 +21,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class HomeController {
     private final HomeService homeService;
 
+    /**
+     * 홈 - 날짜 (dd)
+     * */
     @GetMapping("/month")
-    public BaseResponse<MonthPlanResponse> getPlanOnMonth(HttpServletRequest httpRequest, @RequestBody @Valid MonthPlanRequest planRequest) {
+    public BaseResponse<MonthPlanResponse> getPlanOnMonth(HttpServletRequest httpRequest, @RequestBody @Valid PlanRequest planRequest) {
         MonthPlanResponse response = homeService.getPlanOnMonth(httpRequest, planRequest);
+        return new BaseResponse<>(response);
+    }
+
+    /**
+     * 홈 - 날짜(yyyy-MM-dd) / 시각(hh-mm) / 모임 명 / 약속 명
+     * - '나'의 직접적인 참여 여부와 무관
+     * */
+    @GetMapping("/day")
+    public BaseResponse<DayPlanResponse> getPlanOnDay(HttpServletRequest httpRequest, @RequestBody @Valid PlanRequest planRequest) {
+        DayPlanResponse response = homeService.getPlanOnDay(httpRequest, planRequest);
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/com/kuit/conet/dao/HomeDao.java
+++ b/src/main/java/com/kuit/conet/dao/HomeDao.java
@@ -1,5 +1,6 @@
 package com.kuit.conet.dao;
 
+import com.kuit.conet.domain.FixedPlan;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.SingleColumnRowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -25,11 +26,34 @@ public class HomeDao {
                 "from team_member tm, plan p " +
                 "where tm.team_id = p.team_id " +
                 "and tm.user_id=:user_id and tm.status=1 " +
-                "and p.status=1 and date_format(p.fixed_date,'%Y-%m')=:search_date";
+                "and p.status=2 and date_format(p.fixed_date,'%Y-%m')=:search_date"; // plan status 확정 : 2
         Map<String, Object> param = Map.of("user_id", userId,
                 "search_date", searchDate);
 
         RowMapper<String> mapper = new SingleColumnRowMapper<>(String.class);
+
+        return jdbcTemplate.query(sql, param, mapper);
+    }
+
+    public List<FixedPlan> getPlanOnDay(Long userId, String searchDate) {
+        String sql = "select p.fixed_date as fixed_date, p.fixed_time as fixed_time, p.plan_name as plan_name, t.team_name as team_name " +
+                "from team_member tm, plan p, team t " +
+                "where tm.team_id = p.team_id and p.team_id = t.team_id " +
+                "and tm.user_id=:user_id and tm.status=1 and t.status=1 " +
+                "and p.status=2 and date_format(p.fixed_date,'%Y-%m-%d')=:search_date"; // plan status 대기 : 1
+        Map<String, Object> param = Map.of("user_id", userId,
+                "search_date", searchDate);
+
+        RowMapper<FixedPlan> mapper = (rs, rowNum) -> {
+            FixedPlan plan = new FixedPlan();
+            plan.setDate(rs.getString("fixed_date"));
+            String fixedTime = rs.getString("fixed_time");
+            int timeEndIndex = fixedTime.length()-3;
+            plan.setTime(fixedTime.substring(0, timeEndIndex));
+            plan.setPlanName(rs.getString("plan_name"));
+            plan.setTeamName(rs.getString("team_name"));
+            return plan;
+        };
 
         return jdbcTemplate.query(sql, param, mapper);
     }

--- a/src/main/java/com/kuit/conet/domain/FixedPlan.java
+++ b/src/main/java/com/kuit/conet/domain/FixedPlan.java
@@ -1,0 +1,18 @@
+package com.kuit.conet.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FixedPlan {
+    private String date; // yy-MM-dd
+    private String time; // hh-mm
+    private String teamName;
+    private String planName;
+}
+/*
+ * 날짜 / 시각 / 모임 명 / 약속 명
+ * */

--- a/src/main/java/com/kuit/conet/dto/request/PlanRequest.java
+++ b/src/main/java/com/kuit/conet/dto/request/PlanRequest.java
@@ -6,7 +6,8 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class MonthPlanRequest {
+public class PlanRequest {
     String searchDate;
-    // yyyy-MM
+    // 특정 달의 조회: "yyyy-MM"
+    // 특정 날짜 조회: "yyyy-MM-dd"
 }

--- a/src/main/java/com/kuit/conet/dto/response/DayPlanResponse.java
+++ b/src/main/java/com/kuit/conet/dto/response/DayPlanResponse.java
@@ -1,0 +1,16 @@
+package com.kuit.conet.dto.response;
+
+import com.kuit.conet.domain.FixedPlan;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class DayPlanResponse {
+    int count;
+    List<FixedPlan> plans;
+}

--- a/src/main/java/com/kuit/conet/service/HomeService.java
+++ b/src/main/java/com/kuit/conet/service/HomeService.java
@@ -1,7 +1,9 @@
 package com.kuit.conet.service;
 
 import com.kuit.conet.dao.HomeDao;
-import com.kuit.conet.dto.request.MonthPlanRequest;
+import com.kuit.conet.domain.FixedPlan;
+import com.kuit.conet.dto.request.PlanRequest;
+import com.kuit.conet.dto.response.DayPlanResponse;
 import com.kuit.conet.dto.response.MonthPlanResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +19,7 @@ import java.util.List;
 public class HomeService {
     private final HomeDao homeDao;
 
-    public MonthPlanResponse getPlanOnMonth(HttpServletRequest httpRequest, MonthPlanRequest planRequest) {
+    public MonthPlanResponse getPlanOnMonth(HttpServletRequest httpRequest, PlanRequest planRequest) {
         List<Integer> planDates = new ArrayList<>();
 
         Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
@@ -30,5 +32,14 @@ public class HomeService {
         }
 
         return new MonthPlanResponse(planDates.size(), planDates);
+    }
+
+    public DayPlanResponse getPlanOnDay(HttpServletRequest httpRequest, PlanRequest planRequest) {
+        Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
+        String searchDate = planRequest.getSearchDate(); // yyyy-MM-dd
+
+        List<FixedPlan> plans = homeDao.getPlanOnDay(userId, searchDate);
+
+        return new DayPlanResponse(plans.size(), plans);
     }
 }


### PR DESCRIPTION
## 내가 속한 모임의 약속 중 선택한 날짜에 확정된 약속 조회 기능
단, 내가 참여하지 않는 약속도 표시되어야 함

- 모임 이름
- 약속 이름
- 약속 날짜
- 약속 시각

> 시간이 지난 약속도 포함하여 반환
- `날짜` 단위로만 계산
<br>

### Response Body
```json
{
    "code": 1000,
    "status": 200,
    "message": "요청에 성공하였습니다.",
    "result": {
        "count": 3,
        "plans": [
            {
                "date": "2023-07-22",
                "time": "16:09",
                "teamName": "첫 모임",
                "planName": "첫 약속"
            },
            {
                "date": "2023-07-22",
                "time": "22:14",
                "teamName": "첫 모임",
                "planName": "두 번째 약속"
            },
            {
                "date": "2023-07-22",
                "time": "22:09",
                "teamName": "첫 모임",
                "planName": "세 번째 약속"
            }
        ]
    }
}
```
<br>

### ToDo
- [x] API 구현 마무리
- [x] API 테스트