### PR TITLE
feat(#15): 모임 내 특정 달의 약속 조회

### DIFF
--- a/src/main/java/com/kuit/conet/controller/HomeController.java
+++ b/src/main/java/com/kuit/conet/controller/HomeController.java
@@ -1,10 +1,10 @@
 package com.kuit.conet.controller;
 
 import com.kuit.conet.common.response.BaseResponse;
-import com.kuit.conet.dto.request.home.HomePlanRequest;
-import com.kuit.conet.dto.response.home.HomeDayPlanResponse;
-import com.kuit.conet.dto.response.home.HomeMonthPlanResponse;
-import com.kuit.conet.dto.response.home.HomeWaitingPlanResponse;
+import com.kuit.conet.dto.request.plan.PlanRequest;
+import com.kuit.conet.dto.response.plan.DayPlanResponse;
+import com.kuit.conet.dto.response.plan.MonthPlanResponse;
+import com.kuit.conet.dto.response.plan.WaitingPlanResponse;
 import com.kuit.conet.service.HomeService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -26,8 +26,8 @@ public class HomeController {
      * 홈 - 날짜 (dd)
      * */
     @GetMapping("/month")
-    public BaseResponse<HomeMonthPlanResponse> getPlanOnMonth(HttpServletRequest httpRequest, @RequestBody @Valid HomePlanRequest planRequest) {
-        HomeMonthPlanResponse response = homeService.getPlanOnMonth(httpRequest, planRequest);
+    public BaseResponse<MonthPlanResponse> getPlanInMonth(HttpServletRequest httpRequest, @RequestBody @Valid PlanRequest planRequest) {
+        MonthPlanResponse response = homeService.getPlanInMonth(httpRequest, planRequest);
         return new BaseResponse<>(response);
     }
 
@@ -36,8 +36,8 @@ public class HomeController {
      * - '나'의 직접적인 참여 여부와 무관
      * */
     @GetMapping("/day")
-    public BaseResponse<HomeDayPlanResponse> getPlanOnDay(HttpServletRequest httpRequest, @RequestBody @Valid HomePlanRequest planRequest) {
-        HomeDayPlanResponse response = homeService.getPlanOnDay(httpRequest, planRequest);
+    public BaseResponse<DayPlanResponse> getPlanOnDay(HttpServletRequest httpRequest, @RequestBody @Valid PlanRequest planRequest) {
+        DayPlanResponse response = homeService.getPlanOnDay(httpRequest, planRequest);
         return new BaseResponse<>(response);
     }
 
@@ -46,8 +46,8 @@ public class HomeController {
      * - '나'의 직접적인 참여 여부와 무관
      * */
     @GetMapping("/waiting")
-    public BaseResponse<HomeWaitingPlanResponse> getWaitingPlan(HttpServletRequest httpRequest) {
-        HomeWaitingPlanResponse response = homeService.getWaitingPlanOnDay(httpRequest);
+    public BaseResponse<WaitingPlanResponse> getWaitingPlan(HttpServletRequest httpRequest) {
+        WaitingPlanResponse response = homeService.getWaitingPlanOnDay(httpRequest);
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/com/kuit/conet/controller/HomeController.java
+++ b/src/main/java/com/kuit/conet/controller/HomeController.java
@@ -1,7 +1,7 @@
 package com.kuit.conet.controller;
 
 import com.kuit.conet.common.response.BaseResponse;
-import com.kuit.conet.dto.request.plan.PlanRequest;
+import com.kuit.conet.dto.request.plan.HomePlanRequest;
 import com.kuit.conet.dto.response.plan.DayPlanResponse;
 import com.kuit.conet.dto.response.plan.MonthPlanResponse;
 import com.kuit.conet.dto.response.plan.WaitingPlanResponse;
@@ -26,7 +26,7 @@ public class HomeController {
      * 홈 - 날짜 (dd)
      * */
     @GetMapping("/month")
-    public BaseResponse<MonthPlanResponse> getPlanInMonth(HttpServletRequest httpRequest, @RequestBody @Valid PlanRequest planRequest) {
+    public BaseResponse<MonthPlanResponse> getPlanInMonth(HttpServletRequest httpRequest, @RequestBody @Valid HomePlanRequest planRequest) {
         MonthPlanResponse response = homeService.getPlanInMonth(httpRequest, planRequest);
         return new BaseResponse<>(response);
     }
@@ -36,7 +36,7 @@ public class HomeController {
      * - '나'의 직접적인 참여 여부와 무관
      * */
     @GetMapping("/day")
-    public BaseResponse<DayPlanResponse> getPlanOnDay(HttpServletRequest httpRequest, @RequestBody @Valid PlanRequest planRequest) {
+    public BaseResponse<DayPlanResponse> getPlanOnDay(HttpServletRequest httpRequest, @RequestBody @Valid HomePlanRequest planRequest) {
         DayPlanResponse response = homeService.getPlanOnDay(httpRequest, planRequest);
         return new BaseResponse<>(response);
     }

--- a/src/main/java/com/kuit/conet/controller/HomeController.java
+++ b/src/main/java/com/kuit/conet/controller/HomeController.java
@@ -47,7 +47,7 @@ public class HomeController {
      * */
     @GetMapping("/waiting")
     public BaseResponse<WaitingPlanResponse> getWaitingPlan(HttpServletRequest httpRequest) {
-        WaitingPlanResponse response = homeService.getWaitingPlanOnDay(httpRequest);
+        WaitingPlanResponse response = homeService.getWaitingPlan(httpRequest);
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/com/kuit/conet/controller/PlanController.java
+++ b/src/main/java/com/kuit/conet/controller/PlanController.java
@@ -1,10 +1,8 @@
 package com.kuit.conet.controller;
 
 import com.kuit.conet.common.response.BaseResponse;
-import com.kuit.conet.dto.request.plan.CreatePlanRequest;
-import com.kuit.conet.dto.request.plan.FixPlanRequest;
-import com.kuit.conet.dto.request.plan.PossibleTimeRequest;
-import com.kuit.conet.dto.request.plan.PlanIdRequest;
+import com.kuit.conet.dto.request.plan.*;
+import com.kuit.conet.dto.response.plan.MonthPlanResponse;
 import com.kuit.conet.dto.response.plan.CreatePlanResponse;
 import com.kuit.conet.dto.response.plan.MemberPossibleTimeResponse;
 import com.kuit.conet.dto.response.plan.UserTimeResponse;
@@ -49,6 +47,15 @@ public class PlanController {
     @PostMapping("/fix")
     public BaseResponse<String> fixPlan(@RequestBody @Valid FixPlanRequest fixPlanRequest) {
         String response = planService.fixPlan(fixPlanRequest);
+        return new BaseResponse<>(response);
+    }
+
+    /**
+     * 모임 내 약속 - 날짜 (dd)
+     * */
+    @GetMapping("/month")
+    public BaseResponse<MonthPlanResponse> getPlanInMonth(@RequestBody @Valid TeamFixedPlanRequest planRequest) {
+        MonthPlanResponse response = planService.getPlanInMonth(planRequest);
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/com/kuit/conet/dao/HomeDao.java
+++ b/src/main/java/com/kuit/conet/dao/HomeDao.java
@@ -19,7 +19,7 @@ public class HomeDao {
         this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
     }
 
-    public List<String> getPlanOnMonth(Long userId, String searchDate) {
+    public List<String> getPlanInMonth(Long userId, String searchDate) {
         // 해당 년, 월에 유저가 포함된 모든 모임의 모든 약속 -> fixed_date 만 distinct 로 검색
         // team_member(userId, status) -> plan(teamId, fixed_date, status)
 

--- a/src/main/java/com/kuit/conet/dao/HomeDao.java
+++ b/src/main/java/com/kuit/conet/dao/HomeDao.java
@@ -59,7 +59,7 @@ public class HomeDao {
         return jdbcTemplate.query(sql, param, mapper);
     }
 
-    public List<WaitingPlan> getWaitingPlanOnDay(Long userId) {
+    public List<WaitingPlan> getWaitingPlan(Long userId) {
 //        유저가 속한 모든 모임의 tm.status=1 & tm.userId=:user_id & tm.team_id = p.team_id
 //        모든 대기 중인 약속 중에서 p.status=1
 //        시작 날짜가 오늘 이후 plan_start_period >= current_date();

--- a/src/main/java/com/kuit/conet/dao/PlanDao.java
+++ b/src/main/java/com/kuit/conet/dao/PlanDao.java
@@ -1,13 +1,11 @@
 package com.kuit.conet.dao;
 
-import com.kuit.conet.domain.MemberPossibleTime;
-import com.kuit.conet.domain.Plan;
-import com.kuit.conet.domain.PlanMemberTime;
-import com.kuit.conet.dto.request.plan.FixPlanRequest;
+import com.kuit.conet.domain.*;
 import com.kuit.conet.dto.response.plan.UserPossibleTimeResponse;
 import com.kuit.conet.dto.response.plan.UserTimeResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.SingleColumnRowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -152,5 +150,21 @@ public class PlanDao {
         Map<String, Object> param = Map.of("plan_id", planId);
 
         return jdbcTemplate.queryForObject(sql, param, Boolean.class);
+    }
+
+    public List<String> getPlanInMonth(Long teamId, String searchDate) {
+        // 해당 년, 월에 해당 모임의 모든 약속 -> fixed_date 만 distinct 로 검색
+        // team_member(userId, status) -> plan(teamId, fixed_date, status)
+
+        String sql = "select distinct(fixed_date) " +
+                "from plan " +
+                "where team_id=:team_id and status=2 " +
+                "and date_format(fixed_date,'%Y-%m')=:search_date"; // plan status 확정 : 2
+        Map<String, Object> param = Map.of("team_id", teamId,
+                "search_date", searchDate);
+
+        RowMapper<String> mapper = new SingleColumnRowMapper<>(String.class);
+
+        return jdbcTemplate.query(sql, param, mapper);
     }
 }

--- a/src/main/java/com/kuit/conet/dto/request/plan/HomePlanRequest.java
+++ b/src/main/java/com/kuit/conet/dto/request/plan/HomePlanRequest.java
@@ -6,8 +6,8 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class PlanRequest {
-    String searchDate;
+public class HomePlanRequest {
+    private String searchDate;
     // 특정 달의 조회: "yyyy-MM"
     // 특정 날짜 조회: "yyyy-MM-dd"
 }

--- a/src/main/java/com/kuit/conet/dto/request/plan/PlanRequest.java
+++ b/src/main/java/com/kuit/conet/dto/request/plan/PlanRequest.java
@@ -1,4 +1,4 @@
-package com.kuit.conet.dto.request.home;
+package com.kuit.conet.dto.request.plan;
 
 import lombok.*;
 
@@ -6,7 +6,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class HomePlanRequest {
+public class PlanRequest {
     String searchDate;
     // 특정 달의 조회: "yyyy-MM"
     // 특정 날짜 조회: "yyyy-MM-dd"

--- a/src/main/java/com/kuit/conet/dto/request/plan/TeamFixedPlanRequest.java
+++ b/src/main/java/com/kuit/conet/dto/request/plan/TeamFixedPlanRequest.java
@@ -1,0 +1,17 @@
+package com.kuit.conet.dto.request.plan;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class TeamFixedPlanRequest {
+    private Long teamId;
+    private String searchDate;
+    // 특정 달의 조회: "yyyy-MM"
+    // 특정 날짜 조회: "yyyy-MM-dd"
+}

--- a/src/main/java/com/kuit/conet/dto/request/plan/TeamWaitingPlanRequest.java
+++ b/src/main/java/com/kuit/conet/dto/request/plan/TeamWaitingPlanRequest.java
@@ -1,0 +1,14 @@
+package com.kuit.conet.dto.request.plan;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class TeamWaitingPlanRequest {
+    private Long teamId;
+}

--- a/src/main/java/com/kuit/conet/dto/response/plan/DayPlanResponse.java
+++ b/src/main/java/com/kuit/conet/dto/response/plan/DayPlanResponse.java
@@ -1,4 +1,4 @@
-package com.kuit.conet.dto.response.home;
+package com.kuit.conet.dto.response.plan;
 
 import com.kuit.conet.domain.FixedPlan;
 import lombok.*;
@@ -10,7 +10,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class HomeDayPlanResponse {
+public class DayPlanResponse {
     int count;
     List<FixedPlan> plans;
 }

--- a/src/main/java/com/kuit/conet/dto/response/plan/MonthPlanResponse.java
+++ b/src/main/java/com/kuit/conet/dto/response/plan/MonthPlanResponse.java
@@ -1,4 +1,4 @@
-package com.kuit.conet.dto.response.home;
+package com.kuit.conet.dto.response.plan;
 
 import lombok.*;
 
@@ -9,7 +9,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class HomeMonthPlanResponse {
+public class MonthPlanResponse {
     int count;
     List<Integer> dates;
 }

--- a/src/main/java/com/kuit/conet/dto/response/plan/WaitingPlanResponse.java
+++ b/src/main/java/com/kuit/conet/dto/response/plan/WaitingPlanResponse.java
@@ -1,4 +1,4 @@
-package com.kuit.conet.dto.response.home;
+package com.kuit.conet.dto.response.plan;
 
 import com.kuit.conet.domain.WaitingPlan;
 import lombok.*;
@@ -10,7 +10,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class HomeWaitingPlanResponse {
+public class WaitingPlanResponse {
     private int count;
     private List<WaitingPlan> plans;
 }

--- a/src/main/java/com/kuit/conet/service/HomeService.java
+++ b/src/main/java/com/kuit/conet/service/HomeService.java
@@ -3,10 +3,10 @@ package com.kuit.conet.service;
 import com.kuit.conet.dao.HomeDao;
 import com.kuit.conet.domain.FixedPlan;
 import com.kuit.conet.domain.WaitingPlan;
-import com.kuit.conet.dto.request.home.HomePlanRequest;
-import com.kuit.conet.dto.response.home.HomeDayPlanResponse;
-import com.kuit.conet.dto.response.home.HomeMonthPlanResponse;
-import com.kuit.conet.dto.response.home.HomeWaitingPlanResponse;
+import com.kuit.conet.dto.request.plan.PlanRequest;
+import com.kuit.conet.dto.response.plan.DayPlanResponse;
+import com.kuit.conet.dto.response.plan.MonthPlanResponse;
+import com.kuit.conet.dto.response.plan.WaitingPlanResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,35 +21,35 @@ import java.util.List;
 public class HomeService {
     private final HomeDao homeDao;
 
-    public HomeMonthPlanResponse getPlanOnMonth(HttpServletRequest httpRequest, HomePlanRequest planRequest) {
+    public MonthPlanResponse getPlanInMonth(HttpServletRequest httpRequest, PlanRequest planRequest) {
         List<Integer> planDates = new ArrayList<>();
 
         Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
         String searchDate = planRequest.getSearchDate(); // yyyy-MM
 
-        List<String> dateList = homeDao.getPlanOnMonth(userId, searchDate);
+        List<String> dateList = homeDao.getPlanInMonth(userId, searchDate);
         for(String tempDate : dateList) {
             Integer date = Integer.parseInt(tempDate.split("-")[2]);
             planDates.add(date);
         }
 
-        return new HomeMonthPlanResponse(planDates.size(), planDates);
+        return new MonthPlanResponse(planDates.size(), planDates);
     }
 
-    public HomeDayPlanResponse getPlanOnDay(HttpServletRequest httpRequest, HomePlanRequest planRequest) {
+    public DayPlanResponse getPlanOnDay(HttpServletRequest httpRequest, PlanRequest planRequest) {
         Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
         String searchDate = planRequest.getSearchDate(); // yyyy-MM-dd
 
         List<FixedPlan> plans = homeDao.getPlanOnDay(userId, searchDate);
 
-        return new HomeDayPlanResponse(plans.size(), plans);
+        return new DayPlanResponse(plans.size(), plans);
     }
 
-    public HomeWaitingPlanResponse getWaitingPlanOnDay(HttpServletRequest httpRequest) {
+    public WaitingPlanResponse getWaitingPlanOnDay(HttpServletRequest httpRequest) {
         Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
 
         List<WaitingPlan> plans = homeDao.getWaitingPlanOnDay(userId);
 
-        return new HomeWaitingPlanResponse(plans.size(), plans);
+        return new WaitingPlanResponse(plans.size(), plans);
     }
 }

--- a/src/main/java/com/kuit/conet/service/HomeService.java
+++ b/src/main/java/com/kuit/conet/service/HomeService.java
@@ -3,7 +3,7 @@ package com.kuit.conet.service;
 import com.kuit.conet.dao.HomeDao;
 import com.kuit.conet.domain.FixedPlan;
 import com.kuit.conet.domain.WaitingPlan;
-import com.kuit.conet.dto.request.plan.PlanRequest;
+import com.kuit.conet.dto.request.plan.HomePlanRequest;
 import com.kuit.conet.dto.response.plan.DayPlanResponse;
 import com.kuit.conet.dto.response.plan.MonthPlanResponse;
 import com.kuit.conet.dto.response.plan.WaitingPlanResponse;
@@ -21,7 +21,7 @@ import java.util.List;
 public class HomeService {
     private final HomeDao homeDao;
 
-    public MonthPlanResponse getPlanInMonth(HttpServletRequest httpRequest, PlanRequest planRequest) {
+    public MonthPlanResponse getPlanInMonth(HttpServletRequest httpRequest, HomePlanRequest planRequest) {
         List<Integer> planDates = new ArrayList<>();
 
         Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
@@ -36,7 +36,7 @@ public class HomeService {
         return new MonthPlanResponse(planDates.size(), planDates);
     }
 
-    public DayPlanResponse getPlanOnDay(HttpServletRequest httpRequest, PlanRequest planRequest) {
+    public DayPlanResponse getPlanOnDay(HttpServletRequest httpRequest, HomePlanRequest planRequest) {
         Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
         String searchDate = planRequest.getSearchDate(); // yyyy-MM-dd
 

--- a/src/main/java/com/kuit/conet/service/HomeService.java
+++ b/src/main/java/com/kuit/conet/service/HomeService.java
@@ -45,10 +45,10 @@ public class HomeService {
         return new DayPlanResponse(plans.size(), plans);
     }
 
-    public WaitingPlanResponse getWaitingPlanOnDay(HttpServletRequest httpRequest) {
+    public WaitingPlanResponse getWaitingPlan(HttpServletRequest httpRequest) {
         Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
 
-        List<WaitingPlan> plans = homeDao.getWaitingPlanOnDay(userId);
+        List<WaitingPlan> plans = homeDao.getWaitingPlan(userId);
 
         return new WaitingPlanResponse(plans.size(), plans);
     }

--- a/src/main/java/com/kuit/conet/service/PlanService.java
+++ b/src/main/java/com/kuit/conet/service/PlanService.java
@@ -4,13 +4,8 @@ import com.kuit.conet.common.exception.TeamException;
 import com.kuit.conet.dao.PlanDao;
 import com.kuit.conet.dao.TeamDao;
 import com.kuit.conet.dao.UserDao;
-import com.kuit.conet.domain.MemberPossibleTime;
-import com.kuit.conet.domain.Plan;
-import com.kuit.conet.domain.PlanMemberTime;
-import com.kuit.conet.dto.request.plan.CreatePlanRequest;
-import com.kuit.conet.dto.request.plan.FixPlanRequest;
-import com.kuit.conet.dto.request.plan.PossibleTimeRequest;
-import com.kuit.conet.dto.request.plan.PlanIdRequest;
+import com.kuit.conet.domain.*;
+import com.kuit.conet.dto.request.plan.*;
 import com.kuit.conet.dto.response.plan.*;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -180,4 +175,15 @@ public class PlanService {
         return "약속 확정에 성공하였습니다.";
     }
 
+    public MonthPlanResponse getPlanInMonth(TeamFixedPlanRequest planRequest) {
+        List<Integer> planDates = new ArrayList<>();
+
+        List<String> dateList = planDao.getPlanInMonth(planRequest.getTeamId(), planRequest.getSearchDate()); // yyyy-MM
+        for(String tempDate : dateList) {
+            Integer date = Integer.parseInt(tempDate.split("-")[2]);
+            planDates.add(date);
+        }
+
+        return new MonthPlanResponse(planDates.size(), planDates);
+    }
 }


### PR DESCRIPTION
## 모임 내 특정 달의 확정된 약속 조회 기능
단, 내가 참여하지 않는 약속도 표시되어야 함

- 모임 이름
- 약속 이름
- 약속 날짜
- 약속 시각

> `날짜` 단위로만 계산
<br>

### Response Body
```json
{
    "code": 1000,
    "status": 200,
    "message": "요청에 성공하였습니다.",
    "result": {
        "count": 3,
        "dates": [
            7,
            18,
            20
        ]
    }
}
```