### PR TITLE
feat(#16): 모임 내 특정 날짜의 약속 조회 기능 구현

### DIFF
--- a/src/main/java/com/kuit/conet/controller/PlanController.java
+++ b/src/main/java/com/kuit/conet/controller/PlanController.java
@@ -1,17 +1,18 @@
 package com.kuit.conet.controller;
 
 import com.kuit.conet.common.response.BaseResponse;
+import com.kuit.conet.domain.FixedPlan;
+import com.kuit.conet.domain.WaitingPlan;
 import com.kuit.conet.dto.request.plan.*;
-import com.kuit.conet.dto.response.plan.MonthPlanResponse;
-import com.kuit.conet.dto.response.plan.CreatePlanResponse;
-import com.kuit.conet.dto.response.plan.MemberPossibleTimeResponse;
-import com.kuit.conet.dto.response.plan.UserTimeResponse;
+import com.kuit.conet.dto.response.plan.*;
 import com.kuit.conet.service.PlanService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -56,6 +57,17 @@ public class PlanController {
     @GetMapping("/month")
     public BaseResponse<MonthPlanResponse> getPlanInMonth(@RequestBody @Valid TeamFixedPlanRequest planRequest) {
         MonthPlanResponse response = planService.getPlanInMonth(planRequest);
+        return new BaseResponse<>(response);
+    }
+
+    /**
+     * 모임 내 약속 - 날짜(yyyy-MM-dd) / 시각(hh-mm) / 약속 명
+     * - '나'의 직접적인 참여 여부와 무관
+     * - 모임 명은 필요 없지만 하나의 dto 를 공유하기 위하여 반환함
+     * */
+    @GetMapping("/day")
+    public BaseResponse<DayPlanResponse> getPlanOnDay(@RequestBody @Valid TeamFixedPlanRequest planRequest) {
+        DayPlanResponse response = planService.getPlanOnDay(planRequest);
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/com/kuit/conet/dao/PlanDao.java
+++ b/src/main/java/com/kuit/conet/dao/PlanDao.java
@@ -167,4 +167,27 @@ public class PlanDao {
 
         return jdbcTemplate.query(sql, param, mapper);
     }
+
+    public List<FixedPlan> getPlanOnDay(Long teamId, String searchDate) {
+        String sql = "select p.fixed_date as fixed_date, p.fixed_time as fixed_time, p.plan_name as plan_name, t.team_name as team_name " +
+                "from plan p, team t " +
+                "where p.team_id = t.team_id " +
+                "and p.team_id=:team_id and t.status=1 " +
+                "and p.status=2 and date_format(p.fixed_date,'%Y-%m-%d')=:search_date"; // plan status 확정 : 2
+        Map<String, Object> param = Map.of("team_id", teamId,
+                "search_date", searchDate);
+
+        RowMapper<FixedPlan> mapper = (rs, rowNum) -> {
+            FixedPlan plan = new FixedPlan();
+            plan.setDate(rs.getString("fixed_date"));
+            String fixedTime = rs.getString("fixed_time");
+            int timeEndIndex = fixedTime.length()-3;
+            plan.setTime(fixedTime.substring(0, timeEndIndex));
+            plan.setTeamName(rs.getString("team_name"));
+            plan.setPlanName(rs.getString("plan_name"));
+            return plan;
+        };
+
+        return jdbcTemplate.query(sql, param, mapper);
+    }
 }

--- a/src/main/java/com/kuit/conet/service/PlanService.java
+++ b/src/main/java/com/kuit/conet/service/PlanService.java
@@ -186,4 +186,10 @@ public class PlanService {
 
         return new MonthPlanResponse(planDates.size(), planDates);
     }
+
+    public DayPlanResponse getPlanOnDay(TeamFixedPlanRequest planRequest) {
+        List<FixedPlan> plans = planDao.getPlanOnDay(planRequest.getTeamId(), planRequest.getSearchDate()); // yyyy-MM-dd
+
+        return new DayPlanResponse(plans.size(), plans);
+    }
 }


### PR DESCRIPTION
## 해당 모임의 약속 중 선택한 날짜에 확정된 약속 조회 기능
단, 내가 참여하지 않는 약속도 표시되어야 함

- 모임 이름
- 약속 이름
- 약속 시각

> 시간이 지난 약속도 포함하여 반환
- `날짜` 단위로만 계산

_모임 이름은 필요하지 않지만, dto를 공유하기 위하여 함께 반환_
<br>

### Response Body
```json
{
    "code": 1000,
    "status": 200,
    "message": "요청에 성공하였습니다.",
    "result": {
        "count": 2,
        "plans": [
            {
                "date": "2023-07-20",
                "time": "11:56",
                "teamName": "첫 모임",
                "planName": "두 번째 약속"
            },
            {
                "date": "2023-07-20",
                "time": "20:52",
                "teamName": "첫 모임",
                "planName": "세 번째 약속"
            }
        ]
    }
}
```