### PR TITLE
feat(#17): 모임 내 대기 중인 약속 조회 기능 구현

### DIFF
--- a/src/main/java/com/kuit/conet/controller/PlanController.java
+++ b/src/main/java/com/kuit/conet/controller/PlanController.java
@@ -70,4 +70,15 @@ public class PlanController {
         DayPlanResponse response = planService.getPlanOnDay(planRequest);
         return new BaseResponse<>(response);
     }
+
+    /**
+     * 모임 내 약속 - 날짜(yyyy-MM-dd) / 시각(hh-mm) / 약속 명
+     * - '나'의 직접적인 참여 여부와 무관
+     * - 모임 명은 필요 없지만 하나의 dto 를 공유하기 위하여 반환함
+     * */
+    @GetMapping("/waiting")
+    public BaseResponse<WaitingPlanResponse> getWaitingPlan(@RequestBody @Valid TeamWaitingPlanRequest planRequest) {
+        WaitingPlanResponse response = planService.getWaitingPlan(planRequest);
+        return new BaseResponse<>(response);
+    }
 }

--- a/src/main/java/com/kuit/conet/dao/PlanDao.java
+++ b/src/main/java/com/kuit/conet/dao/PlanDao.java
@@ -190,4 +190,28 @@ public class PlanDao {
 
         return jdbcTemplate.query(sql, param, mapper);
     }
+
+    public List<WaitingPlan> getWaitingPlanInTeam(Long teamId) {
+        // 해당 모임의 p.team_id = ?
+        // 모든 대기 중인 약속 중에서 p.status=1
+        // 시작 날짜가 오늘 이후 plan_start_period >= current_date();
+
+        String sql = "select p.plan_start_period as start_date, p.plan_end_period as end_date, p.plan_name as plan_name, t.team_name as team_name\n" +
+                "from plan p, team t\n" +
+                "where p.team_id = t.team_id\n" +
+                "and p.team_id=:team_id and p.status=1\n" + // plan status 대기 : 1
+                "  and t.status=1 and p.plan_start_period >= current_date()";
+        Map<String, Object> param = Map.of("team_id", teamId);
+
+        RowMapper<WaitingPlan> mapper = (rs, rowNum) -> {
+            WaitingPlan plan = new WaitingPlan();
+            plan.setStartDate(rs.getString("start_date"));
+            plan.setEndDate(rs.getString("end_date"));
+            plan.setPlanName(rs.getString("plan_name"));
+            plan.setTeamName(rs.getString("team_name"));
+            return plan;
+        };
+
+        return jdbcTemplate.query(sql, param, mapper);
+    }
 }

--- a/src/main/java/com/kuit/conet/service/PlanService.java
+++ b/src/main/java/com/kuit/conet/service/PlanService.java
@@ -192,4 +192,10 @@ public class PlanService {
 
         return new DayPlanResponse(plans.size(), plans);
     }
+
+    public WaitingPlanResponse getWaitingPlan(TeamWaitingPlanRequest planRequest) {
+        List<WaitingPlan> plans = planDao.getWaitingPlanInTeam(planRequest.getTeamId());
+
+        return new WaitingPlanResponse(plans.size(), plans);
+    }
 }


### PR DESCRIPTION
## 해당 모임의 약속 중 확정되지 않은 약속 조회 기능
단, 내가 참여하지 않는 약속도 표시되어야 함

- 약속 이름
- 약속 기간 (시작, 마감 날짜)

> 저장된 기간의 시작 날짜가 '오늘'을 기준으로 이전이면 표시하지 않음

_모임 이름은 필요하지 않지만, dto를 공유하기 위하여 함께 반환_
<br>

### Response Body
```json
{
    "code": 1000,
    "status": 200,
    "message": "요청에 성공하였습니다.",
    "result": {
        "count": 1,
        "plans": [
            {
                "startDate": "2023-07-26",
                "endDate": "2023-08-01",
                "teamName": "첫 모임",
                "planName": "두 번째 약속"
            }
        ]
    }
}
```