### PR TITLE
feat(#27): 히스토리 등록 기능 구현

### DIFF
--- a/src/main/java/com/kuit/conet/common/exception/HistoryException.java
+++ b/src/main/java/com/kuit/conet/common/exception/HistoryException.java
@@ -1,0 +1,19 @@
+package com.kuit.conet.common.exception;
+
+import com.kuit.conet.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class HistoryException extends RuntimeException {
+    private final ResponseStatus exceptionStatus;
+
+    public HistoryException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public HistoryException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/com/kuit/conet/common/exception_handler/HistoryExceptionControllerAdvice.java
+++ b/src/main/java/com/kuit/conet/common/exception_handler/HistoryExceptionControllerAdvice.java
@@ -1,0 +1,22 @@
+package com.kuit.conet.common.exception_handler;
+
+import com.kuit.conet.common.exception.HistoryException;
+import com.kuit.conet.common.response.BaseErrorResponse;
+import jakarta.annotation.Priority;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Priority(0)
+@RestControllerAdvice
+public class HistoryExceptionControllerAdvice {
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HistoryException.class)
+    public BaseErrorResponse handel_HistoryException(HistoryException e) {
+        log.error("[handle_HistoryException]", e);
+        return new BaseErrorResponse(e.getExceptionStatus(), e.getMessage());
+    }
+}

--- a/src/main/java/com/kuit/conet/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/conet/common/response/status/BaseExceptionResponseStatus.java
@@ -53,12 +53,18 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     EXPIRED_INVITE_CODE(5502, HttpStatus.BAD_REQUEST.value(),"초대 코드 유효 기간이 만료되었습니다."),
     EXIST_USER_IN_TEAM(5503, HttpStatus.BAD_REQUEST.value(),"모임에 이미 참여 중입니다."),
     NOT_FOUND_TEAM(5504, HttpStatus.NOT_FOUND.value(),"존재하지 않는 모임입니다."),
+    /**
+     * 6000: 약속(Plan) 정보 오류
+     * */
+    NOT_PAST_PLAN(6000, HttpStatus.BAD_REQUEST.value(), "지난 약속이 아니므로 히스토리에 등록할 수 없습니다."),
+    EXIST_HISTORY(6001, HttpStatus.BAD_REQUEST.value(), "이미 히스토리에 등록된 약속입니다."),
+    NOT_FIXED_PLAN(6002, HttpStatus.BAD_REQUEST.value(), "확정된 약속이 아니므로 히스토리에 등록할 수 없습니다."),
 
     /**
      * 9000: 기타 오류
      */
     INVALID_STORAGE_DOMAIN(9000, HttpStatus.BAD_REQUEST.value(), "업로드할 이미지의 도메인이 올바르지 않습니다."),
-    INVALID_FILE_EXTENSION(3002, HttpStatus.BAD_REQUEST.value(), "파일의 형식이 올바르지 않습니다.");
+    INVALID_FILE_EXTENSION(9002, HttpStatus.BAD_REQUEST.value(), "파일의 형식이 올바르지 않습니다.");
 
 
     private final int code;

--- a/src/main/java/com/kuit/conet/controller/HistoryController.java
+++ b/src/main/java/com/kuit/conet/controller/HistoryController.java
@@ -7,10 +7,8 @@ import com.kuit.conet.service.HistoryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -20,8 +18,8 @@ public class HistoryController {
     private final HistoryService historyService;
 
     @PostMapping("/register")
-    public BaseResponse<HistoryRegisterResponse> registerToHistory(@RequestBody @Valid HistoryRegisterRequest registerRequest) {
-        HistoryRegisterResponse response = historyService.registerToHistory(registerRequest);
+    public BaseResponse<HistoryRegisterResponse> registerToHistory(@RequestBody @Valid HistoryRegisterRequest registerRequest, @RequestParam(value = "file") MultipartFile historyImg) {
+        HistoryRegisterResponse response = historyService.registerToHistory(registerRequest, historyImg);
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/com/kuit/conet/controller/HistoryController.java
+++ b/src/main/java/com/kuit/conet/controller/HistoryController.java
@@ -1,0 +1,27 @@
+package com.kuit.conet.controller;
+
+import com.kuit.conet.common.response.BaseResponse;
+import com.kuit.conet.dto.request.history.HistoryRegisterRequest;
+import com.kuit.conet.dto.response.history.HistoryRegisterResponse;
+import com.kuit.conet.service.HistoryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("history")
+public class HistoryController {
+    private final HistoryService historyService;
+
+    @PostMapping("/register")
+    public BaseResponse<HistoryRegisterResponse> registerToHistory(@RequestBody @Valid HistoryRegisterRequest registerRequest) {
+        HistoryRegisterResponse response = historyService.registerToHistory(registerRequest);
+        return new BaseResponse<>(response);
+    }
+}

--- a/src/main/java/com/kuit/conet/controller/HistoryController.java
+++ b/src/main/java/com/kuit/conet/controller/HistoryController.java
@@ -13,12 +13,12 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("history")
+@RequestMapping("/history")
 public class HistoryController {
     private final HistoryService historyService;
 
     @PostMapping("/register")
-    public BaseResponse<HistoryRegisterResponse> registerToHistory(@RequestBody @Valid HistoryRegisterRequest registerRequest, @RequestParam(value = "file") MultipartFile historyImg) {
+    public BaseResponse<HistoryRegisterResponse> registerToHistory(@RequestPart(value = "registerRequest") @Valid HistoryRegisterRequest registerRequest, @RequestPart(value = "file", required = false)  MultipartFile historyImg) {
         HistoryRegisterResponse response = historyService.registerToHistory(registerRequest, historyImg);
         return new BaseResponse<>(response);
     }

--- a/src/main/java/com/kuit/conet/dao/HistoryDao.java
+++ b/src/main/java/com/kuit/conet/dao/HistoryDao.java
@@ -16,13 +16,13 @@ public class HistoryDao {
 
     public HistoryDao(NamedParameterJdbcTemplate jdbcTemplate) { this.jdbcTemplate = jdbcTemplate; }
 
-    public HistoryRegisterResponse registerToHistory(HistoryRegisterRequest registerRequest) {
+    public HistoryRegisterResponse registerToHistory(HistoryRegisterRequest registerRequest, String imgUrl) {
         Map<String, Object> planIdParam = Map.of("plan_id", registerRequest.getPlanId());
 
         // history 테이블에 추가
         String sql = "insert into history (plan_id, history_image_url, description) values (:plan_id, :history_image_url, :description)";
         Map<String, Object> param = Map.of("plan_id", registerRequest.getPlanId(),
-                "history_image_url", registerRequest.getImgUrl(),
+                "history_image_url", imgUrl,
                 "description", registerRequest.getDescription());
         jdbcTemplate.update(sql, param);
 

--- a/src/main/java/com/kuit/conet/dao/HistoryDao.java
+++ b/src/main/java/com/kuit/conet/dao/HistoryDao.java
@@ -1,0 +1,45 @@
+package com.kuit.conet.dao;
+
+import com.kuit.conet.dto.request.history.HistoryRegisterRequest;
+import com.kuit.conet.dto.response.history.HistoryRegisterResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+
+@Slf4j
+@Repository
+public class HistoryDao {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public HistoryDao(NamedParameterJdbcTemplate jdbcTemplate) { this.jdbcTemplate = jdbcTemplate; }
+
+    public HistoryRegisterResponse registerToHistory(HistoryRegisterRequest registerRequest) {
+        Map<String, Object> planIdParam = Map.of("plan_id", registerRequest.getPlanId());
+
+        // history 테이블에 추가
+        String sql = "insert into history (plan_id, history_image_url, description) values (:plan_id, :history_image_url, :description)";
+        Map<String, Object> param = Map.of("plan_id", registerRequest.getPlanId(),
+                "history_image_url", registerRequest.getImgUrl(),
+                "description", registerRequest.getDescription());
+        jdbcTemplate.update(sql, param);
+
+        // plan 테이블의 history 를 1로 업데이트
+        String planUpdateSql = "update plan set history=1 where plan_id=:plan_id and status=2";
+        jdbcTemplate.update(planUpdateSql, planIdParam);
+
+        // 등록한 history id 반환
+        String returnSql = "select history_id from history where plan_id=:plan_id";
+
+        RowMapper<HistoryRegisterResponse> returnMapper = (rs, rowNum) -> {
+            HistoryRegisterResponse response = new HistoryRegisterResponse();
+            response.setHistoryId(rs.getLong("history_id"));
+            return response;
+        };
+
+        return jdbcTemplate.queryForObject(returnSql, planIdParam, returnMapper);
+    }
+
+}

--- a/src/main/java/com/kuit/conet/dao/HistoryDao.java
+++ b/src/main/java/com/kuit/conet/dao/HistoryDao.java
@@ -19,11 +19,17 @@ public class HistoryDao {
     public HistoryRegisterResponse registerToHistory(HistoryRegisterRequest registerRequest, String imgUrl) {
         Map<String, Object> planIdParam = Map.of("plan_id", registerRequest.getPlanId());
 
+        String description = registerRequest.getDescription();
+        if (description == null) description = "";
+
+        String historyImgUrl = imgUrl;
+        if (historyImgUrl == null) historyImgUrl="";
+
         // history 테이블에 추가
         String sql = "insert into history (plan_id, history_image_url, description) values (:plan_id, :history_image_url, :description)";
         Map<String, Object> param = Map.of("plan_id", registerRequest.getPlanId(),
-                "history_image_url", imgUrl,
-                "description", registerRequest.getDescription());
+                "history_image_url", historyImgUrl,
+                "description", description);
         jdbcTemplate.update(sql, param);
 
         // plan 테이블의 history 를 1로 업데이트

--- a/src/main/java/com/kuit/conet/dao/HomeDao.java
+++ b/src/main/java/com/kuit/conet/dao/HomeDao.java
@@ -60,9 +60,9 @@ public class HomeDao {
     }
 
     public List<WaitingPlan> getWaitingPlan(Long userId) {
-//        유저가 속한 모든 모임의 tm.status=1 & tm.userId=:user_id & tm.team_id = p.team_id
-//        모든 대기 중인 약속 중에서 p.status=1
-//        시작 날짜가 오늘 이후 plan_start_period >= current_date();
+        // 유저가 속한 모든 모임의 tm.status=1 & tm.userId=:user_id & tm.team_id = p.team_id
+        // 모든 대기 중인 약속 중에서 p.status=1
+        // 시작 날짜가 오늘 이후 plan_start_period >= current_date();
 
         String sql = "select p.plan_start_period as start_date, p.plan_end_period as end_date, p.plan_name as plan_name, t.team_name as team_name\n" +
                 "from team_member tm, plan p, team t\n" +
@@ -73,8 +73,10 @@ public class HomeDao {
 
         RowMapper<WaitingPlan> mapper = (rs, rowNum) -> {
             WaitingPlan plan = new WaitingPlan();
-            plan.setStartDate(rs.getString("start_date"));
-            plan.setEndDate(rs.getString("end_date"));
+            String startDate = rs.getString("start_date").replace("-", ". ");
+            String endDate = rs.getString("end_date").replace("-", ". ");
+            plan.setStartDate(startDate);
+            plan.setEndDate(endDate);
             plan.setPlanName(rs.getString("plan_name"));
             plan.setTeamName(rs.getString("team_name"));
             return plan;

--- a/src/main/java/com/kuit/conet/dao/PlanDao.java
+++ b/src/main/java/com/kuit/conet/dao/PlanDao.java
@@ -205,8 +205,10 @@ public class PlanDao {
 
         RowMapper<WaitingPlan> mapper = (rs, rowNum) -> {
             WaitingPlan plan = new WaitingPlan();
-            plan.setStartDate(rs.getString("start_date"));
-            plan.setEndDate(rs.getString("end_date"));
+            String startDate = rs.getString("start_date").replace("-", ". ");
+            String endDate = rs.getString("end_date").replace("-", ". ");
+            plan.setStartDate(startDate);
+            plan.setEndDate(endDate);
             plan.setPlanName(rs.getString("plan_name"));
             plan.setTeamName(rs.getString("team_name"));
             return plan;

--- a/src/main/java/com/kuit/conet/dao/PlanDao.java
+++ b/src/main/java/com/kuit/conet/dao/PlanDao.java
@@ -242,8 +242,14 @@ public class PlanDao {
             detail.setTime(fixedTime.substring(0, timeEndIndex));
             if (isRegisteredToHistory) {
                 detail.setIsRegisteredToHistory(true);
-                detail.setHistoryImgUrl(rs.getString("history_image_url"));
-                detail.setHistoryDescription(rs.getString("history_description"));
+
+                String imgUrl = rs.getString("history_image_url");
+                if (imgUrl.equals("")) imgUrl = null;
+                detail.setHistoryImgUrl(imgUrl);
+
+                String description = rs.getString("history_description");
+                if (description.equals("")) description = null;
+                detail.setHistoryDescription(description);
             } else {
                 detail.setIsRegisteredToHistory(false);
                 detail.setHistoryImgUrl(null);

--- a/src/main/java/com/kuit/conet/domain/storage/StorageDomain.java
+++ b/src/main/java/com/kuit/conet/domain/storage/StorageDomain.java
@@ -15,7 +15,8 @@ import static com.kuit.conet.common.response.status.BaseExceptionResponseStatus.
 @AllArgsConstructor
 public enum StorageDomain {
     TEAM("team"),
-    USER("user");
+    USER("user"),
+    HISTORY("history");
 
     private String storage;
 

--- a/src/main/java/com/kuit/conet/domain/user/User.java
+++ b/src/main/java/com/kuit/conet/domain/user/User.java
@@ -18,7 +18,6 @@ public class User {
     private Platform platform;
     private String platformId;
 
-    // TODO: 생성자 작성 (기능 구현에 따라 필요한 경우)
     public User(String email, Platform platform, String platformId) {
         this.email = email;
         this.platform = platform;

--- a/src/main/java/com/kuit/conet/dto/request/history/HistoryRegisterRequest.java
+++ b/src/main/java/com/kuit/conet/dto/request/history/HistoryRegisterRequest.java
@@ -11,6 +11,5 @@ import lombok.ToString;
 @ToString
 public class HistoryRegisterRequest {
     private Long planId;
-    private String imgUrl;
     private String description;
 }

--- a/src/main/java/com/kuit/conet/dto/request/history/HistoryRegisterRequest.java
+++ b/src/main/java/com/kuit/conet/dto/request/history/HistoryRegisterRequest.java
@@ -1,0 +1,16 @@
+package com.kuit.conet.dto.request.history;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class HistoryRegisterRequest {
+    private Long planId;
+    private String imgUrl;
+    private String description;
+}

--- a/src/main/java/com/kuit/conet/dto/response/history/HistoryRegisterResponse.java
+++ b/src/main/java/com/kuit/conet/dto/response/history/HistoryRegisterResponse.java
@@ -1,0 +1,12 @@
+package com.kuit.conet.dto.response.history;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class HistoryRegisterResponse {
+    private Long historyId;
+}

--- a/src/main/java/com/kuit/conet/service/HistoryService.java
+++ b/src/main/java/com/kuit/conet/service/HistoryService.java
@@ -3,11 +3,13 @@ package com.kuit.conet.service;
 import com.kuit.conet.common.exception.HistoryException;
 import com.kuit.conet.dao.HistoryDao;
 import com.kuit.conet.dao.PlanDao;
+import com.kuit.conet.domain.storage.StorageDomain;
 import com.kuit.conet.dto.request.history.HistoryRegisterRequest;
 import com.kuit.conet.dto.response.history.HistoryRegisterResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import static com.kuit.conet.common.response.status.BaseExceptionResponseStatus.*;
 
@@ -17,8 +19,9 @@ import static com.kuit.conet.common.response.status.BaseExceptionResponseStatus.
 public class HistoryService {
     private final HistoryDao historyDao;
     private final PlanDao planDao;
+    private final StorageService storageService;
 
-    public HistoryRegisterResponse registerToHistory(HistoryRegisterRequest registerRequest) {
+    public HistoryRegisterResponse registerToHistory(HistoryRegisterRequest registerRequest, MultipartFile historyImg) {
         Long planId = registerRequest.getPlanId();
 
         // 확정된 약속인지 검사
@@ -36,7 +39,13 @@ public class HistoryService {
             throw new HistoryException(EXIST_HISTORY);
         }
 
+        // 저장할 파일명 만들기
+        // 받은 파일이 이미지 타입이 아닌 경우에 대한 유효성 검사 진행
+        String fileName = storageService.getFileName(historyImg, StorageDomain.HISTORY, planId);
+        // 새로운 이미지 S3에 업로드
+        String imgUrl = storageService.uploadToS3(historyImg, fileName);
+
         // history 에 등록
-        return historyDao.registerToHistory(registerRequest);
+        return historyDao.registerToHistory(registerRequest, imgUrl);
     }
 }

--- a/src/main/java/com/kuit/conet/service/HistoryService.java
+++ b/src/main/java/com/kuit/conet/service/HistoryService.java
@@ -1,0 +1,42 @@
+package com.kuit.conet.service;
+
+import com.kuit.conet.common.exception.HistoryException;
+import com.kuit.conet.dao.HistoryDao;
+import com.kuit.conet.dao.PlanDao;
+import com.kuit.conet.dto.request.history.HistoryRegisterRequest;
+import com.kuit.conet.dto.response.history.HistoryRegisterResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import static com.kuit.conet.common.response.status.BaseExceptionResponseStatus.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+    private final HistoryDao historyDao;
+    private final PlanDao planDao;
+
+    public HistoryRegisterResponse registerToHistory(HistoryRegisterRequest registerRequest) {
+        Long planId = registerRequest.getPlanId();
+
+        // 확정된 약속인지 검사
+        if (!planDao.isFixedPlan(planId)) {
+            throw new HistoryException(NOT_FIXED_PLAN);
+        }
+
+        // '오늘'을 기준으로 지난 약속인지 검사
+        if (!planDao.isPastPlan(planId)) {
+            throw new HistoryException(NOT_PAST_PLAN);
+        }
+
+        // history 에 이미 등록된 약속인지 확인
+        if (planDao.isRegisteredToHistory(planId)) {
+            throw new HistoryException(EXIST_HISTORY);
+        }
+
+        // history 에 등록
+        return historyDao.registerToHistory(registerRequest);
+    }
+}

--- a/src/main/java/com/kuit/conet/service/HistoryService.java
+++ b/src/main/java/com/kuit/conet/service/HistoryService.java
@@ -39,11 +39,17 @@ public class HistoryService {
             throw new HistoryException(EXIST_HISTORY);
         }
 
-        // 저장할 파일명 만들기
-        // 받은 파일이 이미지 타입이 아닌 경우에 대한 유효성 검사 진행
-        String fileName = storageService.getFileName(historyImg, StorageDomain.HISTORY, planId);
-        // 새로운 이미지 S3에 업로드
-        String imgUrl = storageService.uploadToS3(historyImg, fileName);
+        // 이미지의 경우 파일이 들어오지 않았을 때, S3 관련 행위를 일체 하지 않아야 함
+        String imgUrl = null;
+        if (!historyImg.isEmpty()){
+            // 저장할 파일명 만들기
+            // 받은 파일이 이미지 타입이 아닌 경우에 대한 유효성 검사 진행
+            String fileName = storageService.getFileName(historyImg, StorageDomain.HISTORY, planId);
+            // 새로운 이미지 S3에 업로드
+            imgUrl = storageService.uploadToS3(historyImg, fileName);
+        } else {
+            log.warn("히스토리 이미지 파일이 입력되지 않았습니다.");
+        }
 
         // history 에 등록
         return historyDao.registerToHistory(registerRequest, imgUrl);


### PR DESCRIPTION
## 히스토리 등록 기능 구현
지난 약속 중 히스토리에 등록하는 기능
- 이미지
- 상세 설명

### Validation
1. 확정된 약속인가
2. `오늘(현재)`를 기준으로 지난 약속인가
3. 히스토리에 이미 등록된 약속인가
4. 이미지 또는 상세 설명이 null 값(입력되지 않은 경우)인가
    - null인 경우 DB에는 "" (빈 문자열)로 삽입됨
    - 이를 조회하는 곳에서 빈 문자열일 경우 null로 반환

### Response Body
```json
{
    "code": 1000,
    "status": 200,
    "message": "요청에 성공하였습니다.",
    "result": {
        "historyId": 3
    }
}
```