### PR TITLE
feat(#63): 모임 조회할 때 isNew, 구성원 수 반환

### DIFF
--- a/src/main/java/com/kuit/conet/dao/TeamDao.java
+++ b/src/main/java/com/kuit/conet/dao/TeamDao.java
@@ -102,17 +102,20 @@ public class TeamDao {
         return team;
     }
 
-    public List<GetTeamResponse> getTeam(Long userId) {
-        String sql = "select t.team_name, t.team_image_url " +
+    public List<Team> getTeam(Long userId) {
+        String sql = "select t.team_id, t.team_name, t.team_image_url, t.created_at, t.is_new " +
                 "from team_member as tm join team as t on tm.team_id=t.team_id " +
                 "where tm.user_id=:user_id and tm.status=1";
         Map<String, Object> param = Map.of("user_id", userId);
 
-        RowMapper<GetTeamResponse> mapper = (rs, rowNum) -> {
-            GetTeamResponse response = new GetTeamResponse();
-            response.setTeam_name(rs.getString("team_name"));
-            response.setTeam_image_url(rs.getString("team_image_url"));
-            return response;
+        RowMapper<Team> mapper = (rs, rowNum) -> {
+            Team team = new Team();
+            team.setTeamId(rs.getLong("team_id"));
+            team.setTeamName(rs.getString("team_name"));
+            team.setTeamImgUrl(rs.getString("team_image_url"));
+            team.setCodeGeneratedTime(rs.getTimestamp("created_at"));
+            team.setIsNew(rs.getBoolean("is_new"));
+            return team;
         };
 
         return jdbcTemplate.query(sql, param, mapper);
@@ -224,5 +227,20 @@ public class TeamDao {
         Map<String, Object> param = Map.of("team_id", teamId);
 
         return jdbcTemplate.queryForObject(sql, param, String.class);
+    }
+
+    public Timestamp getCreatedTime(Long teamId) {
+        String sql = "select created_at from team where team_id=:team_id and status=1";
+        Map<String, Object> param = Map.of("team_id", teamId);
+
+        return jdbcTemplate.queryForObject(sql, param, Timestamp.class);
+    }
+
+    public void updatdIsNew(Integer isNew, Long teamId) {
+        String sql = "update team set is_new=:is_new where team_id=:team_id";
+        Map<String, Object> param = Map.of("is_new", isNew,
+                "team_id", teamId);
+
+        jdbcTemplate.update(sql, param);
     }
 }

--- a/src/main/java/com/kuit/conet/domain/team/Team.java
+++ b/src/main/java/com/kuit/conet/domain/team/Team.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.sql.Time;
 import java.sql.Timestamp;
 
 @Getter
@@ -16,6 +17,8 @@ public class Team {
     private String inviteCode;
     private Timestamp codeGeneratedTime;
     private Boolean status;
+    private Timestamp createdAt;
+    private Boolean isNew;
 
     public Team(String teamName, String teamImgUrl, String inviteCode, Timestamp codeGeneratedTime) {
         this.teamName = teamName;
@@ -23,4 +26,12 @@ public class Team {
         this.inviteCode = inviteCode;
         this.codeGeneratedTime = codeGeneratedTime;
     }
-}
+
+    public Team(Long teamId, String teamName, String teamImgUrl, Timestamp createdAt, Boolean isNew) {
+        this.teamId = teamId;
+        this.teamName = teamName;
+        this.teamImgUrl = teamImgUrl;
+        this.createdAt = createdAt;
+        this.isNew = isNew;
+    }
+ }

--- a/src/main/java/com/kuit/conet/dto/response/team/GetTeamResponse.java
+++ b/src/main/java/com/kuit/conet/dto/response/team/GetTeamResponse.java
@@ -2,12 +2,24 @@ package com.kuit.conet.dto.response.team;
 
 import lombok.*;
 
+import java.sql.Timestamp;
+
 @Setter
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
 public class GetTeamResponse {
-    private String team_name;
-    private String team_image_url;
+    private Long teamId;
+    private String teamName;
+    private String teamImgUrl;
+    private Long teamMemberCount;
+    private Boolean isNew;
+
+    public GetTeamResponse(Long teamId, String teamName, String teamImgUrl, Boolean isNew) {
+        this.teamId = teamId;
+        this.teamName = teamName;
+        this.teamImgUrl = teamImgUrl;
+        this.isNew = isNew;
+    }
 }


### PR DESCRIPTION
- create_at 과 현재시각 비교 후 3일 넘게 차이 나면 is_new 필드 false로 update
- 모임 내 구성원 수 반환

### Response Body
```json
{
    "code": 1000,
    "status": 200,
    "message": "요청에 성공하였습니다.",
    "result": [
        {
            "teamId": 1,
            "teamName": "첫 번째 모임",
            "teamImgUrl": "",
            "teamMemberCount": 6,
            "isNew": false,
            "bookmark": true
        },
        {
            "teamId": 10,
            "teamName": "여섯 번째 모임",
            "teamImgUrl": "https://conet-bucket.s3.ap-northeast-2.amazonaws.com/10-teamImage-2023-07-18T17-25-10-427314.png",
            "teamMemberCount": 1,
            "isNew": true,
            "bookmark": true
        }
    ]
}
```