### PR TITLE
feat(#74): 모임 지난 약속 조회 기능 구현

### DIFF
--- a/src/main/java/com/kuit/conet/controller/PlanController.java
+++ b/src/main/java/com/kuit/conet/controller/PlanController.java
@@ -1,7 +1,9 @@
 package com.kuit.conet.controller;
 
 import com.kuit.conet.common.response.BaseResponse;
+import com.kuit.conet.domain.plan.PastPlan;
 import com.kuit.conet.dto.request.plan.*;
+import com.kuit.conet.dto.request.team.TeamIdRequest;
 import com.kuit.conet.dto.response.plan.*;
 import com.kuit.conet.service.PlanService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,6 +11,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -98,6 +102,15 @@ public class PlanController {
     @PostMapping("/update-waiting")
     public BaseResponse<String> updateWaitingPlan(@RequestBody @Valid UpdateWaitingPlanRequest planRequest) {
         String response = planService.updateWaitingPlan(planRequest);
+        return new BaseResponse<>(response);
+    }
+
+    /**
+     * 지난 약속 - 모임 내 사이드바 메뉴
+     * */
+    @GetMapping("/past")
+    public BaseResponse<List<PastPlan>> getPastPlan(@ModelAttribute @Valid TeamIdRequest planRequest) {
+        List<PastPlan> response = planService.getPastPlan(planRequest);
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/com/kuit/conet/dao/PlanDao.java
+++ b/src/main/java/com/kuit/conet/dao/PlanDao.java
@@ -1,6 +1,7 @@
 package com.kuit.conet.dao;
 
 import com.kuit.conet.domain.plan.*;
+import com.kuit.conet.domain.plan.PastPlan;
 import com.kuit.conet.dto.response.plan.UserPossibleTimeResponse;
 import com.kuit.conet.dto.response.plan.UserTimeResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -321,5 +322,27 @@ public class PlanDao {
                 "plan_name", planName);
 
         jdbcTemplate.update(sql, param);
+    }
+
+    public List<PastPlan> getPastPlan(Long teamId) {
+        String sql = "select fixed_date, fixed_time, plan_name, history\n" +
+                        "from plan\n" +
+                        "where team_id=:team_id and status=2;";
+        Map<String, Object> param = Map.of("team_id", teamId);
+
+        RowMapper<PastPlan> mapper = (rs, rowNum) -> {
+            PastPlan plan = new PastPlan();
+            String date = rs.getString("fixed_date").replace("-", ". ");
+            String time = rs.getString("fixed_time");
+            int timeEndIndex = time.length()-3;
+
+            plan.setDate(date);
+            plan.setTime(time.substring(0, timeEndIndex));
+            plan.setPlanName(rs.getString("plan_name"));
+            plan.setIsRegisteredToHistory(rs.getBoolean("history"));
+            return plan;
+        };
+
+        return jdbcTemplate.query(sql, param, mapper);
     }
 }

--- a/src/main/java/com/kuit/conet/domain/plan/PastPlan.java
+++ b/src/main/java/com/kuit/conet/domain/plan/PastPlan.java
@@ -1,0 +1,15 @@
+package com.kuit.conet.domain.plan;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PastPlan {
+    private String date;
+    private String time;
+    private String planName;
+    private Boolean isRegisteredToHistory;
+}

--- a/src/main/java/com/kuit/conet/service/PlanService.java
+++ b/src/main/java/com/kuit/conet/service/PlanService.java
@@ -6,6 +6,7 @@ import com.kuit.conet.dao.TeamDao;
 import com.kuit.conet.dao.UserDao;
 import com.kuit.conet.domain.plan.*;
 import com.kuit.conet.dto.request.plan.*;
+import com.kuit.conet.dto.request.team.TeamIdRequest;
 import com.kuit.conet.dto.response.plan.*;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -219,5 +220,10 @@ public class PlanService {
 
         planDao.updateWaitingPlan(planRequest.getPlanId(), planRequest.getPlanName());
         return "대기 중인 약속 수정에 성공하였습니다.";
+    }
+
+    public List<PastPlan> getPastPlan(TeamIdRequest planRequest) {
+        Long teamId = planRequest.getTeamId();
+        return planDao.getPastPlan(teamId);
     }
 }


### PR DESCRIPTION
## 모임 사이드바 지난 약속 조회 기능 구현

- 모임 날짜
- 모임 시각
- 약속 이름
- 히스토리 등록 여부

### Response Body
```json
{
    "code": 1000,
    "status": 200,
    "message": "요청에 성공하였습니다.",
    "result": [
        {
            "date": "2023. 07. 25",
            "time": "21:30",
            "planName": "첫 약속",
            "isRegisteredToHistory": false
        },
        {
            "date": "2023. 07. 20",
            "time": "20:52",
            "planName": "세 번째 약속",
            "isRegisteredToHistory": true
        }
    ]
}
```