### PR TITLE
feat(#75): 모임 확정 약속 조회 기능 구현

### DIFF
--- a/src/main/java/com/kuit/conet/controller/PlanController.java
+++ b/src/main/java/com/kuit/conet/controller/PlanController.java
@@ -1,6 +1,7 @@
 package com.kuit.conet.controller;
 
 import com.kuit.conet.common.response.BaseResponse;
+import com.kuit.conet.domain.plan.FixedPlan;
 import com.kuit.conet.domain.plan.PastPlan;
 import com.kuit.conet.dto.request.plan.*;
 import com.kuit.conet.dto.request.team.TeamIdRequest;
@@ -111,6 +112,15 @@ public class PlanController {
     @GetMapping("/past")
     public BaseResponse<List<PastPlan>> getPastPlan(@ModelAttribute @Valid TeamIdRequest planRequest) {
         List<PastPlan> response = planService.getPastPlan(planRequest);
+        return new BaseResponse<>(response);
+    }
+
+    /**
+     * 확정 약속 - 모임 내 사이드바 메뉴
+     * */
+    @GetMapping("/fixed")
+    public BaseResponse<List<FixedPlan>> getFixedPlan(@ModelAttribute @Valid TeamIdRequest planRequest) {
+        List<FixedPlan> response = planService.getFixedPlan(planRequest);
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/com/kuit/conet/domain/plan/FixedPlan.java
+++ b/src/main/java/com/kuit/conet/domain/plan/FixedPlan.java
@@ -10,9 +10,12 @@ import lombok.Setter;
 public class FixedPlan {
     private String date; // yyyy-MM-dd
     private String time; // hh-mm
+    private Long dDay;
     private String teamName;
     private String planName;
 }
 /*
  * 날짜 / 시각 / 모임 명 / 약속 명
- * */
+ * 디데이 추가
+ *   - 시간 관계 없이 ‘오늘’을 기준으로 며칠 남았는지
+ */

--- a/src/main/java/com/kuit/conet/service/PlanService.java
+++ b/src/main/java/com/kuit/conet/service/PlanService.java
@@ -226,4 +226,9 @@ public class PlanService {
         Long teamId = planRequest.getTeamId();
         return planDao.getPastPlan(teamId);
     }
+
+    public List<FixedPlan> getFixedPlan(TeamIdRequest planRequest) {
+        Long teamId = planRequest.getTeamId();
+        return planDao.getFixedPlan(teamId);
+    }
 }


### PR DESCRIPTION
## 모임 확정 약속 조회 기능
확정된 약속 중 앞으로(미래) 있을 약속 조회 기능

### Response Body
```json
{
    "code": 1000,
    "status": 200,
    "message": "요청에 성공하였습니다.",
    "result": [
        {
            "date": "2023. 09. 03",
            "time": "21:30",
            "teamName": null,
            "planName": "첫 약속",
            "dday": 38
        }
    ]
}
```