### PR TITLE
fix(#64): 약속 상세 정보 조회 구성원 id 추가

### DIFF
--- a/src/main/java/com/kuit/conet/controller/PlanController.java
+++ b/src/main/java/com/kuit/conet/controller/PlanController.java
@@ -91,8 +91,8 @@ public class PlanController {
      * - 모임 명은 필요 없지만 하나의 dto 를 공유하기 위하여 반환함
      * */
     @GetMapping("/detail")
-    public BaseResponse<List<PlanDetail>> getPlanDetail(@ModelAttribute @Valid PlanIdRequest planRequest) {
-        List<PlanDetail> response = planService.getPlanDetail(planRequest);
+    public BaseResponse<PlanDetail> getPlanDetail(@ModelAttribute @Valid PlanIdRequest planRequest) {
+        PlanDetail response = planService.getPlanDetail(planRequest);
         return new BaseResponse<>(response);
     }
 

--- a/src/main/java/com/kuit/conet/domain/plan/PlanDetail.java
+++ b/src/main/java/com/kuit/conet/domain/plan/PlanDetail.java
@@ -15,7 +15,7 @@ public class PlanDetail {
     private String date; // yyyy-MM-dd
     private String time; // hh:mm
     private List<String> members;
-    //TODO: List<Long> memberIds 추가
+    private List<Long> membersId;
 
     private Boolean isRegisteredToHistory;
     // 히스토리에 등록되어 있을 때

--- a/src/main/java/com/kuit/conet/service/PlanService.java
+++ b/src/main/java/com/kuit/conet/service/PlanService.java
@@ -202,14 +202,15 @@ public class PlanService {
         return new WaitingPlanResponse(plans.size(), plans);
     }
 
-    public List<PlanDetail> getPlanDetail(PlanIdRequest planRequest) {
+    public PlanDetail getPlanDetail(PlanIdRequest planRequest) {
         Long planId = planRequest.getPlanId();
 
         // 히스토리 등록 여부
         Boolean isRegisteredToHistory = planDao.isRegisteredToHistory(planId);
+        log.info("isRegisteredToHistory: {}", isRegisteredToHistory);
 
         // 약속 상세 정보
-        List<PlanDetail> details = planDao.getPlanDetail(planRequest.getPlanId(), isRegisteredToHistory);
+        PlanDetail details = planDao.getPlanDetail(planRequest.getPlanId(), isRegisteredToHistory);
 
         // TODO: history 에서 검색은 되지만, 이미지랑 설명이 모두 null 인 경우 history 테이블에서 삭제 후 isRegisteredToHistory false 처리
 


### PR DESCRIPTION
## 약속 상세 정보 조회 반환 값에 구성원 userId 리스트 추가

### Response Body
```json
{
    "code": 1000,
    "status": 200,
    "message": "요청에 성공하였습니다.",
    "result": {
        "planId": 5,
        "planName": "iOS 개발 만남",
        "date": "2023. 07. 20",
        "time": "19:00",
        "members": [
            "유가은",
            "이안진",
            "정아현"
        ],
        "membersId": [
            5,
            7,
            8
        ],
        "isRegisteredToHistory": true,
        "historyImgUrl": "temp image url",
        "historyDescription": "iOS 모임의 개발 만남"
    }
}
```